### PR TITLE
own: add librtmp2 RTMP-server support + RTMPPanel install flow

### DIFF
--- a/.github/workflows/test-full-matrix.yml
+++ b/.github/workflows/test-full-matrix.yml
@@ -159,6 +159,23 @@ jobs:
             slspanel: "y"
             slspanel_login: "n"
 
+          # RTMPPanel only (no login)
+          - arch: amd64
+            runner: ubuntu-latest
+            lang: en
+            lang_input: "2"
+            yes: "y"
+            no: "n"
+            variant: rtmppanel-only-no-login
+            sys_update: "n"
+            docker_install: "n"
+            wud: "n"
+            wud_labels: "n"
+            rtmp: "n"
+            srtla: "n"
+            slspanel: "n"
+            slspanel_login: "n"
+
           # RTMP + SRTLA only (no SLSPanel, no WUD)
           - arch: amd64
             runner: ubuntu-latest
@@ -331,6 +348,23 @@ jobs:
             rtmp: "n"
             srtla: "n"
             slspanel: "j"
+            slspanel_login: "n"
+
+          # RTMPPanel only (no login)
+          - arch: amd64
+            runner: ubuntu-latest
+            lang: de
+            lang_input: "1"
+            yes: "j"
+            no: "n"
+            variant: rtmppanel-only-no-login
+            sys_update: "n"
+            docker_install: "n"
+            wud: "n"
+            wud_labels: "n"
+            rtmp: "n"
+            srtla: "n"
+            slspanel: "n"
             slspanel_login: "n"
 
           # RTMP + SRTLA only (no SLSPanel, no WUD)
@@ -507,6 +541,23 @@ jobs:
             slspanel: "y"
             slspanel_login: "n"
 
+          # RTMPPanel only (no login)
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+            lang: en
+            lang_input: "2"
+            yes: "y"
+            no: "n"
+            variant: rtmppanel-only-no-login
+            sys_update: "n"
+            docker_install: "n"
+            wud: "n"
+            wud_labels: "n"
+            rtmp: "n"
+            srtla: "n"
+            slspanel: "n"
+            slspanel_login: "n"
+
           # RTMP + SRTLA only (no SLSPanel, no WUD)
           - arch: arm64
             runner: ubuntu-24.04-arm
@@ -681,6 +732,23 @@ jobs:
             slspanel: "j"
             slspanel_login: "n"
 
+          # RTMPPanel only (no login)
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+            lang: de
+            lang_input: "1"
+            yes: "j"
+            no: "n"
+            variant: rtmppanel-only-no-login
+            sys_update: "n"
+            docker_install: "n"
+            wud: "n"
+            wud_labels: "n"
+            rtmp: "n"
+            srtla: "n"
+            slspanel: "n"
+            slspanel_login: "n"
+
           # RTMP + SRTLA only (no SLSPanel, no WUD)
           - arch: arm64
             runner: ubuntu-24.04-arm
@@ -738,8 +806,8 @@ jobs:
       - name: Make script executable
         run: chmod +x ./install.sh
 
-      #- name: Patch set -e for CI pipefail compatibility
-      #  run: sed -i 's/^set -e$/set -eo pipefail/' install.sh
+     # - name: Patch set -e for CI pipefail compatibility
+     #   run: sed -i 's/^set -e$/set -eo pipefail/' install.sh
 
       - name: Ensure Docker is available
         run: |
@@ -768,6 +836,10 @@ jobs:
           ${{ matrix.slspanel_login }}
           admin
           password
+          ${{ matrix.yes }}
+          ${{ matrix.yes }}
+          admin
+          password
           SCRIPT_EOF
 
       # -- Variant: all-with-update-no-docker ------
@@ -793,6 +865,10 @@ jobs:
           ${{ matrix.slspanel_login }}
           admin
           password
+          ${{ matrix.yes }}
+          ${{ matrix.yes }}
+          admin
+          password
           SCRIPT_EOF
 
       # -- Variant: all-with-docker-no-update ------
@@ -815,6 +891,10 @@ jobs:
           ${{ matrix.srtla }}
           ${{ matrix.slspanel }}
           ${{ matrix.slspanel_login }}
+          admin
+          password
+          ${{ matrix.yes }}
+          ${{ matrix.yes }}
           admin
           password
           SCRIPT_EOF
@@ -842,6 +922,10 @@ jobs:
           ${{ matrix.slspanel_login }}
           admin
           password
+          ${{ matrix.yes }}
+          ${{ matrix.yes }}
+          admin
+          password
           SCRIPT_EOF
 
       # -- Variant: rtmp-only ----------------------
@@ -860,6 +944,7 @@ jobs:
           ${{ matrix.no }}
           ${{ matrix.no }}
           ${{ matrix.yes }}
+          ${{ matrix.no }}
           ${{ matrix.no }}
           ${{ matrix.no }}
           SCRIPT_EOF
@@ -882,6 +967,7 @@ jobs:
           ${{ matrix.no }}
           ${{ matrix.yes }}
           ${{ matrix.no }}
+          ${{ matrix.no }}
           SCRIPT_EOF
 
       # -- Variant: slspanel-only-no-login ---------
@@ -897,6 +983,29 @@ jobs:
           ${{ matrix.no }}
           ${{ matrix.no }}
           ${{ matrix.yes }}
+          ${{ matrix.no }}
+          ${{ matrix.no }}
+          ${{ matrix.no }}
+          ${{ matrix.no }}
+          ${{ matrix.yes }}
+          ${{ matrix.no }}
+          ${{ matrix.no }}
+          SCRIPT_EOF
+
+      # -- Variant: rtmppanel-only-no-login --------
+      - name: "Run install (rtmppanel-only-no-login)"
+        if: matrix.variant == 'rtmppanel-only-no-login'
+        env:
+          DEBIAN_FRONTEND: noninteractive
+        run: |
+          ./install.sh <<'SCRIPT_EOF'
+          ${{ matrix.lang_input }}
+          1
+          ${{ matrix.no }}
+          ${{ matrix.no }}
+          ${{ matrix.no }}
+          ${{ matrix.yes }}
+          ${{ matrix.no }}
           ${{ matrix.no }}
           ${{ matrix.no }}
           ${{ matrix.no }}
@@ -923,6 +1032,7 @@ jobs:
           ${{ matrix.yes }}
           ${{ matrix.yes }}
           ${{ matrix.no }}
+          ${{ matrix.no }}
           SCRIPT_EOF
 
       # -- Variant: all-no-wud-no-login ------------
@@ -944,6 +1054,8 @@ jobs:
           ${{ matrix.yes }}
           ${{ matrix.yes }}
           ${{ matrix.no }}
+          ${{ matrix.yes }}
+          ${{ matrix.no }}
           SCRIPT_EOF
 
       # -- Variant: wud-only -----------------------
@@ -961,6 +1073,7 @@ jobs:
           ${{ matrix.yes }}
           ${{ matrix.no }}
           ${{ matrix.yes }}
+          ${{ matrix.no }}
           ${{ matrix.no }}
           ${{ matrix.no }}
           ${{ matrix.no }}
@@ -986,17 +1099,19 @@ jobs:
           }
           case "$VARIANT" in
             all-no-docker-no-update|all-with-update-no-docker|all-with-docker-no-update|all-with-docker-and-update)
-              for c in rtmp-server srtla-server slspanel wud; do check_container "$c"; done ;;
+              for c in rtmp-server srtla-server slspanel rtmppanel wud; do check_container "$c"; done ;;
             rtmp-only)
               check_container "rtmp-server" ;;
             srtla-only)
               check_container "srtla-server" ;;
             slspanel-only-no-login)
               check_container "slspanel" ;;
+            rtmppanel-only-no-login)
+              check_container "rtmppanel" ;;
             rtmp-srtla-only)
               for c in rtmp-server srtla-server; do check_container "$c"; done ;;
             all-no-wud-no-login)
-              for c in rtmp-server srtla-server slspanel; do check_container "$c"; done ;;
+              for c in rtmp-server srtla-server slspanel rtmppanel; do check_container "$c"; done ;;
             wud-only)
               check_container "wud" ;;
           esac
@@ -1029,10 +1144,32 @@ jobs:
             echo "⚠️  .apikey not found (Container evtl. container may still be initializing)"
           fi
 
+      - name: Assert .rtmp_api_token exists (RTMP variants)
+        if: |
+          matrix.variant == 'all-no-docker-no-update' ||
+          matrix.variant == 'all-with-update-no-docker' ||
+          matrix.variant == 'all-with-docker-no-update' ||
+          matrix.variant == 'all-with-docker-and-update' ||
+          matrix.variant == 'rtmp-only' ||
+          matrix.variant == 'rtmp-srtla-only' ||
+          matrix.variant == 'all-no-wud-no-login'
+        run: |
+          sleep 8
+          if [ -f ".rtmp_api_token" ]; then
+            TOKEN=$(cat .rtmp_api_token)
+            if [ -n "$TOKEN" ]; then
+              echo "✅ .rtmp_api_token exists and is non-empty (${#TOKEN} chars)"
+            else
+              echo "⚠️  .rtmp_api_token exists but is empty"
+            fi
+          else
+            echo "⚠️  .rtmp_api_token not found (container may still be initializing)"
+          fi
+
       - name: Container health summary
         run: |
           echo "=== Container Health ==="
-          for cname in rtmp-server srtla-server slspanel wud; do
+          for cname in rtmp-server srtla-server slspanel rtmppanel wud; do
             if docker ps --format '{{.Names}}' | grep -q "^${cname}$"; then
               STATUS=$(docker inspect --format='{{.State.Status}}' "$cname" 2>/dev/null || echo "unknown")
               HEALTH=$(docker inspect --format='{{.State.Health.Status}}' "$cname" 2>/dev/null || echo "no healthcheck")
@@ -1044,7 +1181,7 @@ jobs:
         if: failure()
         run: |
           echo "=== Container Logs ==="
-          for cname in rtmp-server srtla-server slspanel wud; do
+          for cname in rtmp-server srtla-server slspanel rtmppanel wud; do
             if docker ps -a --format '{{.Names}}' | grep -q "^${cname}$"; then
               echo "--- $cname ---"
               docker logs --tail 50 "$cname" 2>&1 || true
@@ -1222,6 +1359,10 @@ jobs:
           ${{ matrix.yes }}
           admin
           password
+          ${{ matrix.yes }}
+          ${{ matrix.yes }}
+          admin
+          password
           SCRIPT_EOF
 
       - name: Wait for containers to be ready
@@ -1238,7 +1379,7 @@ jobs:
           echo "=== Containers after stop ==="
           docker ps -a --format "table {{.Names}}\t{{.Status}}"
           FAILED=0
-          for c in rtmp-server srtla-server slspanel; do
+          for c in rtmp-server srtla-server slspanel rtmppanel; do
             STATUS=$(docker inspect --format='{{.State.Status}}' "$c" 2>/dev/null || echo "missing")
             if [ "$STATUS" = "exited" ] || [ "$STATUS" = "missing" ]; then
               echo "✅ $c is stopped ($STATUS)"
@@ -1266,7 +1407,7 @@ jobs:
           echo "=== Containers after start ==="
           docker ps --format "table {{.Names}}\t{{.Status}}"
           FAILED=0
-          for c in rtmp-server srtla-server slspanel; do
+          for c in rtmp-server srtla-server slspanel rtmppanel; do
             if docker ps --format '{{.Names}}' | grep -q "^${c}$"; then
               echo "✅ $c is running"
             else
@@ -1287,7 +1428,7 @@ jobs:
           echo "=== Containers after update ==="
           docker ps --format "table {{.Names}}\t{{.Status}}"
           FAILED=0
-          for c in rtmp-server srtla-server slspanel; do
+          for c in rtmp-server srtla-server slspanel rtmppanel; do
             if docker ps --format '{{.Names}}' | grep -q "^${c}$"; then
               echo "✅ $c is running after update"
             else
@@ -1309,11 +1450,13 @@ jobs:
           echo "=== Containers after uninstall ==="
           docker ps -a
           docker volume ls
-          if docker volume ls | grep -q "srtla-server"; then
-            echo "✅ Volume srtla-server still exists (correct)"
-          else
-            echo "ℹ️  Volume srtla-server not found"
-          fi
+          for v in srtla-server rtmp-server-data rtmppanel-data; do
+            if docker volume ls | grep -q "$v"; then
+              echo "✅ Volume $v still exists (correct)"
+            else
+              echo "ℹ️  Volume $v not found"
+            fi
+          done
 
       # ── Action: uninstall-remove-volumes ─────
       - name: "Lifecycle: uninstall (remove volumes)"
@@ -1327,17 +1470,31 @@ jobs:
           echo "=== Containers after uninstall ==="
           docker ps -a
           docker volume ls
+          FAILED=0
           if docker volume ls | grep -q "srtla-server"; then
             echo "❌ Volume srtla-server still exists but should be removed!"
-            exit 1
+            FAILED=1
           else
             echo "✅ Volume srtla-server was removed (correct)"
           fi
+          if docker volume ls | grep -q "rtmp-server-data"; then
+            echo "❌ Volume rtmp-server-data still exists but should be removed!"
+            FAILED=1
+          else
+            echo "✅ Volume rtmp-server-data was removed (correct)"
+          fi
+          if docker volume ls | grep -q "rtmppanel-data"; then
+            echo "❌ Volume rtmppanel-data still exists but should be removed!"
+            FAILED=1
+          else
+            echo "✅ Volume rtmppanel-data was removed (correct)"
+          fi
+          exit $FAILED
 
       - name: Show logs on failure
         if: failure()
         run: |
-          for cname in rtmp-server srtla-server slspanel wud; do
+          for cname in rtmp-server srtla-server slspanel rtmppanel wud; do
             if docker ps -a --format '{{.Names}}' | grep -q "^${cname}$"; then
               echo "--- $cname ---"
               docker logs --tail 50 "$cname" 2>&1 || true

--- a/install.sh
+++ b/install.sh
@@ -180,7 +180,7 @@ function extract_api_key_with_retry() {
 
 function extract_rtmp_api_token() {
   local token=""
-  token=$(docker logs rtmp-server 2>/dev/null | grep -A1 "Generated API token" | tail -1 | tr -d '[:space:]')
+  token=$(docker logs rtmp-server 2>/dev/null | grep -A1 "Generated API token" | grep -E '^[A-Za-z0-9]{32,}$' | tail -1 | tr -d '[:space:]')
   echo "$token"
 }
 
@@ -459,6 +459,7 @@ function update_services() {
       rtmp_token=$(extract_rtmp_api_token_with_retry)
       if [[ -n "$rtmp_token" ]]; then
         echo "$rtmp_token" > .rtmp_api_token
+        chmod 600 .rtmp_api_token
         [[ "$lang" == "de" ]] && echo -e "${SUCCESS}RTMP API-Token erfolgreich extrahiert.${NC}" || echo -e "${SUCCESS}RTMP API token successfully extracted.${NC}"
       fi
     fi
@@ -779,6 +780,7 @@ if [[ "$mainaction" == "1" ]]; then
       rtmp_token=$(extract_rtmp_api_token_with_retry)
       if [[ -n "$rtmp_token" ]]; then
         echo "$rtmp_token" > .rtmp_api_token
+        chmod 600 .rtmp_api_token
         if [[ "$lang" == "de" ]]; then
           echo -e "${SUCCESS}RTMP API-Token erfolgreich extrahiert und gespeichert.${NC}"
         else

--- a/install.sh
+++ b/install.sh
@@ -456,7 +456,7 @@ function update_services() {
     rtmp_token=$(cat .rtmp_api_token 2>/dev/null || echo "")
     if [[ -z "$rtmp_token" ]]; then
       [[ "$lang" == "de" ]] && echo -e "${INFO}Versuche RTMP API-Token neu zu extrahieren...${NC}" || echo -e "${INFO}Trying to re-extract RTMP API token...${NC}"
-      rtmp_token=$(extract_rtmp_api_token_with_retry)
+      rtmp_token=$(extract_rtmp_api_token_with_retry) || true
       if [[ -n "$rtmp_token" ]]; then
         echo "$rtmp_token" > .rtmp_api_token
         chmod 600 .rtmp_api_token
@@ -777,7 +777,7 @@ if [[ "$mainaction" == "1" ]]; then
       else
         echo -e "${INFO}Waiting for the container to fully initialize...${NC}"
       fi
-      rtmp_token=$(extract_rtmp_api_token_with_retry)
+      rtmp_token=$(extract_rtmp_api_token_with_retry) || true
       if [[ -n "$rtmp_token" ]]; then
         echo "$rtmp_token" > .rtmp_api_token
         chmod 600 .rtmp_api_token

--- a/install.sh
+++ b/install.sh
@@ -14,24 +14,24 @@ INFO="${YELLOW}"
 
 function print_ascii_art_de() {
   cat <<"EOF"
-  ____  _                              ____      _               ___           _        _ _           
- / ___|| |_ _ __ ___  __ _ _ __ ___   |  _ \  ___| | __ _ _   _  |_ _|_ __  ___| |_ __ _| | | ___ _ __ 
+  ____  _                              ____      _               ___           _        _ _
+ / ___|| |_ _ __ ___  __ _ _ __ ___   |  _ \  ___| | __ _ _   _  |_ _|_ __  ___| |_ __ _| | | ___ _ __
  \___ \| __| '__/ _ \/ _` | '_ ` _ \  | |_) / _ \ |/ _` | | | |  | || '_ \/ __| __/ _` | | |/ _ \ '__|
-  ___) | |_| | |  __/ (_| | | | | | | |  _ <  __/ | (_| | |_| |  | || | | \__ \ || (_| | | |  __/ |   
- |____/ \__|_|  \___|\__,_|_| |_| |_| |_| \_\___|_|\__,_|\__, | |___|_| |_|___/\__\__,_|_|_|\___|_|   
-                                                         |___/                                                                                                                   
+  ___) | |_| | |  __/ (_| | | | | | | |  _ <  __/ | (_| | |_| |  | || | | \__ \ || (_| | | |  __/ |
+ |____/ \__|_|  \___|\__,_|_| |_| |_| |_| \_\___|_|\__,_|\__, | |___|_| |_|___/\__\__,_|_|_|\___|_|
+                                                         |___/
            von AlexanderWagnerDev
 EOF
 }
 
 function print_ascii_art_en() {
   cat <<"EOF"
-  ____  _                              ____      _               ___           _        _ _           
- / ___|| |_ _ __ ___  __ _ _ __ ___   |  _ \  ___| | __ _ _   _  |_ _|_ __  ___| |_ __ _| | | ___ _ __ 
+  ____  _                              ____      _               ___           _        _ _
+ / ___|| |_ _ __ ___  __ _ _ __ ___   |  _ \  ___| | __ _ _   _  |_ _|_ __  ___| |_ __ _| | | ___ _ __
  \___ \| __| '__/ _ \/ _` | '_ ` _ \  | |_) / _ \ |/ _` | | | |  | || '_ \/ __| __/ _` | | |/ _ \ '__|
-  ___) | |_| | |  __/ (_| | | | | | | |  _ <  __/ | (_| | |_| |  | || | | \__ \ || (_| | | |  __/ |   
- |____/ \__|_|  \___|\__,_|_| |_| |_| |_| \_\___|_|\__,_|\__, | |___|_| |_|___/\__\__,_|_|_|\___|_|   
-                                                         |___/                                                                                                                                                
+  ___) | |_| | |  __/ (_| | | | | | | |  _ <  __/ | (_| | |_| |  | || | | \__ \ || (_| | | |  __/ |
+ |____/ \__|_|  \___|\__,_|_| |_| |_| |_| \_\___|_|\__,_|\__, | |___|_| |_|___/\__\__,_|_|_|\___|_|
+                                                         |___/
            by AlexanderWagnerDev
 EOF
 }
@@ -178,6 +178,56 @@ function extract_api_key_with_retry() {
   return 1
 }
 
+function extract_rtmp_api_token() {
+  local token=""
+  token=$(docker logs rtmp-server 2>/dev/null | grep -A1 "Generated API token" | tail -1 | tr -d '[:space:]')
+  echo "$token"
+}
+
+function extract_rtmp_api_token_with_retry() {
+  local max_attempts=5
+  local wait_seconds=5
+  local attempt=1
+  local token=""
+
+  while [[ $attempt -le $max_attempts ]]; do
+    if [[ "$lang" == "de" ]]; then
+      echo -e "${INFO}Versuche RTMP API-Token zu extrahieren (Versuch $attempt/$max_attempts)...${NC}" >&2
+    else
+      echo -e "${INFO}Trying to extract RTMP API token (attempt $attempt/$max_attempts)...${NC}" >&2
+    fi
+    token=$(extract_rtmp_api_token)
+    if [[ -n "$token" ]]; then
+      echo "$token"
+      return 0
+    fi
+    if [[ $attempt -lt $max_attempts ]]; then
+      if [[ "$lang" == "de" ]]; then
+        echo -e "${INFO}RTMP API-Token noch nicht verfügbar, warte ${wait_seconds}s...${NC}" >&2
+      else
+        echo -e "${INFO}RTMP API token not yet available, waiting ${wait_seconds}s...${NC}" >&2
+      fi
+      sleep "$wait_seconds"
+    fi
+    attempt=$((attempt + 1))
+  done
+
+  echo ""
+  return 1
+}
+
+function get_or_create_rtmppanel_secret() {
+  if [ -f ".rtmppanel_secret" ]; then
+    cat .rtmppanel_secret
+    return
+  fi
+  local secret=""
+  secret=$(openssl rand -hex 32 2>/dev/null || python3 -c 'import secrets; print(secrets.token_hex(32))' 2>/dev/null)
+  echo "$secret" > .rtmppanel_secret
+  chmod 600 .rtmppanel_secret
+  echo "$secret"
+}
+
 function print_available_services() {
   local app_url="$1"
   local management_port="$2"
@@ -189,6 +239,7 @@ function print_available_services() {
   local p_sls_stats_port="$8"
   local p_rtmp_stats_port="$9"
   local p_rtmp_port="${10}"
+  local p_rtmppanel_port="${11}"
   if [[ "$lang" == "de" ]]; then
     echo -e "${HEADER}Verfügbare Dienste:${NC}"
     echo -e "${SUCCESS}SLSPanel UI: http://${p_public_ip}:${management_port}${NC}"
@@ -198,8 +249,11 @@ function print_available_services() {
     echo -e "${SUCCESS}SRT Sender URL ZUM SENDEN (Beispiel): srt://${p_public_ip}:${p_srt_sender_port}?streamid=livekey${NC}"
     echo -e "${SUCCESS}SRT Player URL ZUM EMPFANGEN (Beispiel): srt://${p_public_ip}:${p_srt_player_port}?streamid=playkey${NC}"
     echo -e "${SUCCESS}SRT/SRTLA Statistiken URL (Beispiel): http://${p_public_ip}:${p_sls_stats_port}/stats/playkey${NC}"
-    echo -e "${SUCCESS}RTMP Statistiken URL: http://${p_public_ip}:${p_rtmp_stats_port}/stats${NC}"
-    echo -e "${SUCCESS}RTMP URL ZUM SENDEN UND EMPFANGEN (Beispiel): rtmp://${p_public_ip}:${p_rtmp_port}/publish/livekey${NC}"
+    echo -e "${SUCCESS}RTMP Statistiken/API URL: http://${p_public_ip}:${p_rtmp_stats_port}/api/v1/health${NC}"
+    echo -e "${SUCCESS}RTMP URL ZUM SENDEN UND EMPFANGEN (Beispiel): rtmp://${p_public_ip}:${p_rtmp_port}/live/DEIN_PUBLISH_KEY${NC}"
+    if [[ -n "$p_rtmppanel_port" ]]; then
+      echo -e "${SUCCESS}RTMPPanel UI: http://${p_public_ip}:${p_rtmppanel_port}${NC}"
+    fi
   else
     echo -e "${HEADER}Available services:${NC}"
     echo -e "${SUCCESS}SLSPanel UI: http://${p_public_ip}:${management_port}${NC}"
@@ -209,8 +263,11 @@ function print_available_services() {
     echo -e "${SUCCESS}SRT Sender URL TO SEND (Example): srt://${p_public_ip}:${p_srt_sender_port}?streamid=livekey${NC}"
     echo -e "${SUCCESS}SRT Player URL TO RECEIVE (Example): srt://${p_public_ip}:${p_srt_player_port}?streamid=playkey${NC}"
     echo -e "${SUCCESS}SRT/SRTLA Statistics URL (Example): http://${p_public_ip}:${p_sls_stats_port}/stats/playkey${NC}"
-    echo -e "${SUCCESS}RTMP Stats URL: http://${p_public_ip}:${p_rtmp_stats_port}/stats${NC}"
-    echo -e "${SUCCESS}RTMP URL FOR SENDING AND RECEIVING (Example): rtmp://${p_public_ip}:${p_rtmp_port}/publish/livekey${NC}"
+    echo -e "${SUCCESS}RTMP Stats/API URL: http://${p_public_ip}:${p_rtmp_stats_port}/api/v1/health${NC}"
+    echo -e "${SUCCESS}RTMP URL FOR SENDING AND RECEIVING (Example): rtmp://${p_public_ip}:${p_rtmp_port}/live/YOUR_PUBLISH_KEY${NC}"
+    if [[ -n "$p_rtmppanel_port" ]]; then
+      echo -e "${SUCCESS}RTMPPanel UI: http://${p_public_ip}:${p_rtmppanel_port}${NC}"
+    fi
   fi
 }
 
@@ -258,7 +315,7 @@ function health_check() {
 }
 
 function stop_services() {
-  for cname in rtmp-server srtla-server slspanel wud; do
+  for cname in rtmp-server srtla-server slspanel rtmppanel wud; do
     if docker ps --format '{{.Names}}' | grep -q "^$cname$"; then
       docker stop "$cname" || true
       [[ "$lang" == "de" ]] && echo -e "${INFO}Container $cname gestoppt.${NC}" || echo -e "${INFO}Stopped container $cname.${NC}"
@@ -267,7 +324,7 @@ function stop_services() {
 }
 
 function start_services() {
-  for cname in rtmp-server srtla-server slspanel wud; do
+  for cname in rtmp-server srtla-server slspanel rtmppanel wud; do
     docker start "$cname" 2>/dev/null || true
     health_check "$cname"
   done
@@ -371,9 +428,9 @@ function recreate_container() {
 function update_services() {
   [[ "$lang" == "de" ]] && echo -e "${HEADER}=== Container-Update wird gestartet ===${NC}" || echo -e "${HEADER}=== Starting container update ===${NC}"
 
-  local containers=("rtmp-server" "srtla-server" "slspanel" "wud")
-  local images=("alexanderwagnerdev/rtmp-server:own" "alexanderwagnerdev/srtla-server:own" "alexanderwagnerdev/slspanel:own" "getwud/wud:latest")
-  local fallback_images=("ghcr.io/alexanderwagnerdev/rtmp-server:own" "ghcr.io/alexanderwagnerdev/srtla-server:own" "ghcr.io/alexanderwagnerdev/slspanel:own" "ghcr.io/getwud/wud:latest")
+  local containers=("rtmp-server" "srtla-server" "slspanel" "rtmppanel" "wud")
+  local images=("alexanderwagnerdev/rtmp-server:own" "alexanderwagnerdev/srtla-server:own" "alexanderwagnerdev/slspanel:own" "alexanderwagnerdev/rtmppanel:own" "getwud/wud:latest")
+  local fallback_images=("ghcr.io/alexanderwagnerdev/rtmp-server:own" "ghcr.io/alexanderwagnerdev/srtla-server:own" "ghcr.io/alexanderwagnerdev/slspanel:own" "ghcr.io/alexanderwagnerdev/rtmppanel:own" "ghcr.io/getwud/wud:latest")
 
   for i in "${!containers[@]}"; do
     recreate_container "${containers[$i]}" "${images[$i]}" "${fallback_images[$i]}"
@@ -393,16 +450,29 @@ function update_services() {
       fi
     fi
   fi
+
+  if docker ps -a --format '{{.Names}}' | grep -q "^rtmp-server$"; then
+    local rtmp_token
+    rtmp_token=$(cat .rtmp_api_token 2>/dev/null || echo "")
+    if [[ -z "$rtmp_token" ]]; then
+      [[ "$lang" == "de" ]] && echo -e "${INFO}Versuche RTMP API-Token neu zu extrahieren...${NC}" || echo -e "${INFO}Trying to re-extract RTMP API token...${NC}"
+      rtmp_token=$(extract_rtmp_api_token_with_retry)
+      if [[ -n "$rtmp_token" ]]; then
+        echo "$rtmp_token" > .rtmp_api_token
+        [[ "$lang" == "de" ]] && echo -e "${SUCCESS}RTMP API-Token erfolgreich extrahiert.${NC}" || echo -e "${SUCCESS}RTMP API token successfully extracted.${NC}"
+      fi
+    fi
+  fi
 }
 
 function uninstall_services() {
-  for cname in rtmp-server srtla-server slspanel wud; do
+  for cname in rtmp-server srtla-server slspanel rtmppanel wud; do
     if docker ps -a --format '{{.Names}}' | grep -q "^$cname$"; then
       docker rm -f "$cname" || true
       [[ "$lang" == "de" ]] && echo -e "${INFO}Container $cname entfernt.${NC}" || echo -e "${INFO}Removed container $cname.${NC}"
     fi
   done
-  for img in alexanderwagnerdev/rtmp-server alexanderwagnerdev/srtla-server alexanderwagnerdev/slspanel getwud/wud; do
+  for img in alexanderwagnerdev/rtmp-server alexanderwagnerdev/srtla-server alexanderwagnerdev/slspanel alexanderwagnerdev/rtmppanel getwud/wud; do
     docker rmi -f "$img" 2>/dev/null || true
     docker rmi -f "ghcr.io/$img" 2>/dev/null || true
   done
@@ -416,11 +486,23 @@ function uninstall_services() {
     fi
   fi
 
+  if [ -f ".rtmp_api_token" ]; then
+    rm -f ".rtmp_api_token"
+    if [[ "$lang" == "de" ]]; then
+      echo -e "${SUCCESS}RTMP API-Token Datei (.rtmp_api_token) gelöscht.${NC}"
+    else
+      echo -e "${SUCCESS}RTMP API token file (.rtmp_api_token) deleted.${NC}"
+    fi
+  fi
+
   if [[ "$lang" == "de" ]]; then
     read -rp $'\033[1;33mSollen auch Volumes gelöscht werden? (j/n):\033[0m ' rmvol
     if [[ "$rmvol" =~ ^[Jj] ]]; then
       docker volume rm srtla-server 2>/dev/null || true
-      echo -e "${SUCCESS}Docker-Volume srtla-server entfernt.${NC}"
+      docker volume rm rtmp-server-data 2>/dev/null || true
+      docker volume rm rtmppanel-data 2>/dev/null || true
+      rm -f ".rtmppanel_secret"
+      echo -e "${SUCCESS}Docker-Volumes (srtla-server, rtmp-server-data, rtmppanel-data) entfernt.${NC}"
     else
       echo -e "${INFO}Volumes bleiben erhalten.${NC}"
     fi
@@ -429,7 +511,10 @@ function uninstall_services() {
     read -rp $'\033[1;33mShould volumes be deleted as well? (y/n):\033[0m ' rmvol
     if [[ "$rmvol" =~ ^[Yy] ]]; then
       docker volume rm srtla-server 2>/dev/null || true
-      echo -e "${SUCCESS}Docker volume srtla-server removed.${NC}"
+      docker volume rm rtmp-server-data 2>/dev/null || true
+      docker volume rm rtmppanel-data 2>/dev/null || true
+      rm -f ".rtmppanel_secret"
+      echo -e "${SUCCESS}Docker volumes (srtla-server, rtmp-server-data, rtmppanel-data) removed.${NC}"
     else
       echo -e "${INFO}Volumes are kept.${NC}"
     fi
@@ -458,7 +543,7 @@ if [[ "$lang" == "de" ]]; then
   rtmp_prompt="RTMP-Server Docker Container installieren und starten? (j/n):"
   srtla_prompt="SRTLA-Server Docker Container installieren und starten? (j/n):"
   wud_prompt="WUD Container (automatische Updates) installieren und starten? (j/n):"
-  wud_labels_prompt="Sollen die Container (RTMP, SRTLA, SLSPanel) von WUD überwacht werden? (j/n):"
+  wud_labels_prompt="Sollen die Container (RTMP, SRTLA, SLSPanel, RTMPPanel) von WUD überwacht werden? (j/n):"
   ipv6_prompt="Docker IPv6 Unterstützung aktivieren? (j/n):"
   use_default_ports_prompt="Standardports verwenden? (j/n):"
   manual_ip_prompt="Möchtest du eine Domain oder IP manuell eingeben? (j/n):"
@@ -467,6 +552,10 @@ if [[ "$lang" == "de" ]]; then
   slspanel_login_prompt="Login für SLSPanel aktivieren? (j/n): "
   slspanel_username_prompt="Benutzername für SLSPanel Admin: "
   slspanel_password_prompt="Passwort für SLSPanel Admin: "
+  rtmppanel_install_prompt="RTMPPanel installieren und starten? (j/n): "
+  rtmppanel_login_prompt="Login für RTMPPanel aktivieren? (j/n): "
+  rtmppanel_username_prompt="Benutzername für RTMPPanel Admin: "
+  rtmppanel_password_prompt="Passwort für RTMPPanel Admin: "
   done_msg="Setup abgeschlossen."
   docker_install_msg="Docker Installation wird gestartet..."
   docker_skip_msg="Docker wird nicht installiert."
@@ -476,6 +565,8 @@ if [[ "$lang" == "de" ]]; then
   srtla_skip_msg="SRTLA-Server wird nicht installiert."
   wud_install_msg="Starte WUD Docker-Container..."
   wud_skip_msg="WUD wird nicht installiert."
+  rtmppanel_install_msg="Starte RTMPPanel Docker-Container..."
+  rtmppanel_skip_msg="RTMPPanel wird nicht installiert."
   ipv6_enable_msg="Docker IPv6 Unterstützung wird aktiviert..."
   ipv6_skip_msg="Docker IPv6 Unterstützung wird nicht aktiviert."
   restart_msg="${YELLOW}Bitte beachten: Nach Docker-Installation ist evtl. ein Neustart oder eine neue Anmeldung nötig, damit Docker-Gruppenrechte aktiv werden.${NC}"
@@ -484,16 +575,17 @@ if [[ "$lang" == "de" ]]; then
     "Port für SRT-Sender (Standard: 4001)"
     "Port für SRTLA (Standard: 5000)"
     "Port für SLS Stats (Standard: 8789)"
-    "Port für RTMP-Server Stats/Web (Standard: 8090)"
+    "Port für RTMP-Server Stats/API (Standard: 8090)"
     "Port für RTMP (Standard: 1935)"
     "Port für SLSPanel WebUI (Standard: 8000)"
+    "Port für RTMPPanel WebUI (Standard: 8001)"
   )
 else
   docker_prompt="Install Docker? (y/n):"
   rtmp_prompt="Install and start RTMP Server Docker container? (y/n):"
   srtla_prompt="Install and start SRTLA Server Docker container? (y/n):"
   wud_prompt="Install and start WUD container (automatic updates)? (y/n):"
-  wud_labels_prompt="Should the containers (RTMP, SRTLA, SLSPanel) be monitored by WUD? (y/n):"
+  wud_labels_prompt="Should the containers (RTMP, SRTLA, SLSPanel, RTMPPanel) be monitored by WUD? (y/n):"
   ipv6_prompt="Enable Docker IPv6 support? (y/n):"
   use_default_ports_prompt="Use default ports? (y/n):"
   manual_ip_prompt="Do you want to enter a domain or IP manually? (y/n):"
@@ -502,6 +594,10 @@ else
   slspanel_login_prompt="Enable login for SLSPanel? (y/n): "
   slspanel_username_prompt="Username for SLSPanel admin: "
   slspanel_password_prompt="Password for SLSPanel admin: "
+  rtmppanel_install_prompt="Install and start RTMPPanel? (y/n): "
+  rtmppanel_login_prompt="Enable login for RTMPPanel? (y/n): "
+  rtmppanel_username_prompt="Username for RTMPPanel admin: "
+  rtmppanel_password_prompt="Password for RTMPPanel admin: "
   done_msg="Setup completed."
   docker_install_msg="Starting Docker installation..."
   docker_skip_msg="Skipping Docker installation."
@@ -511,6 +607,8 @@ else
   srtla_skip_msg="Skipping SRTLA Server installation."
   wud_install_msg="Starting WUD Docker container..."
   wud_skip_msg="Skipping WUD installation."
+  rtmppanel_install_msg="Starting RTMPPanel Docker container..."
+  rtmppanel_skip_msg="Skipping RTMPPanel installation."
   ipv6_enable_msg="Enabling Docker IPv6 support..."
   ipv6_skip_msg="Not enabling Docker IPv6 support."
   restart_msg="${YELLOW}Please note: After Docker installation a reboot or re-login might be necessary to activate Docker group permissions.${NC}"
@@ -519,9 +617,10 @@ else
     "Port for SRT Sender (default: 4001)"
     "Port for SRTLA (default: 5000)"
     "Port for SLS Stats (default: 8789)"
-    "Port for RTMP Server Stats/Web (default: 8090)"
+    "Port for RTMP Server Stats/API (default: 8090)"
     "Port for RTMP (default: 1935)"
     "Port for SLSPanel WebUI (default: 8000)"
+    "Port for RTMPPanel WebUI (default: 8001)"
   )
 fi
 
@@ -605,6 +704,7 @@ if [[ "$mainaction" == "1" ]]; then
     rtmp_stats_port=8090
     rtmp_port=1935
     slspanel_port=8000
+    rtmppanel_port=8001
   else
     srt_player_port=$(read_port "${port_prompts[0]}" 4000)
     srt_sender_port=$(read_port "${port_prompts[1]}" 4001)
@@ -613,6 +713,7 @@ if [[ "$mainaction" == "1" ]]; then
     rtmp_stats_port=$(read_port "${port_prompts[4]}" 8090)
     rtmp_port=$(read_port "${port_prompts[5]}" 1935)
     slspanel_port=$(read_port "${port_prompts[6]}" 8000)
+    rtmppanel_port=$(read_port "${port_prompts[7]}" 8001)
   fi
 
   MANUAL_IP=""
@@ -657,15 +758,46 @@ if [[ "$mainaction" == "1" ]]; then
         --label "wud.watch=true" \
         --label "wud.watch.digest=true" \
         --label "wud.tag.include=^own$" \
-        -p "${rtmp_stats_port}":80/tcp -p "${rtmp_port}":1935/tcp \
+        -v rtmp-server-data:/data \
+        -p "${rtmp_stats_port}":8080/tcp -p "${rtmp_port}":1935/tcp \
         alexanderwagnerdev/rtmp-server:own
     else
       docker run -d --name rtmp-server --restart unless-stopped \
-        -p "${rtmp_stats_port}":80/tcp -p "${rtmp_port}":1935/tcp \
+        -v rtmp-server-data:/data \
+        -p "${rtmp_stats_port}":8080/tcp -p "${rtmp_port}":1935/tcp \
         alexanderwagnerdev/rtmp-server:own
     fi
 
     health_check rtmp-server
+
+    if [ ! -f ".rtmp_api_token" ]; then
+      if [[ "$lang" == "de" ]]; then
+        echo -e "${INFO}Warte auf vollständiges Initialisieren des Containers...${NC}"
+      else
+        echo -e "${INFO}Waiting for the container to fully initialize...${NC}"
+      fi
+      rtmp_token=$(extract_rtmp_api_token_with_retry)
+      if [[ -n "$rtmp_token" ]]; then
+        echo "$rtmp_token" > .rtmp_api_token
+        if [[ "$lang" == "de" ]]; then
+          echo -e "${SUCCESS}RTMP API-Token erfolgreich extrahiert und gespeichert.${NC}"
+        else
+          echo -e "${SUCCESS}RTMP API token successfully extracted and saved.${NC}"
+        fi
+      else
+        if [[ "$lang" == "de" ]]; then
+          echo -e "${ERROR}RTMP API-Token konnte nicht extrahiert werden.${NC}"
+        else
+          echo -e "${ERROR}RTMP API token could not be extracted.${NC}"
+        fi
+      fi
+    else
+      if [[ "$lang" == "de" ]]; then
+        echo -e "${SUCCESS}RTMP API-Token bereits vorhanden in .rtmp_api_token${NC}"
+      else
+        echo -e "${SUCCESS}RTMP API token already present in .rtmp_api_token${NC}"
+      fi
+    fi
   else
     echo -e "$rtmp_skip_msg"
   fi
@@ -852,6 +984,112 @@ if [[ "$mainaction" == "1" ]]; then
     fi
   fi
 
+  read -rp "$rtmppanel_install_prompt" install_rtmppanel
+  install_rtmppanel=${install_rtmppanel:-n}
+  if [[ "$install_rtmppanel" =~ ^[JjYy] ]]; then
+
+    read -rp "$rtmppanel_login_prompt" rtmppanel_enable_login
+    rtmppanel_enable_login=${rtmppanel_enable_login:-n}
+
+    if [[ "$rtmppanel_enable_login" =~ ^[JjYy] ]]; then
+      read -rp "$rtmppanel_username_prompt" rtmppanel_username
+      rtmppanel_username=${rtmppanel_username:-admin}
+      read -rsp "$rtmppanel_password_prompt" rtmppanel_password
+      echo ""
+    else
+      rtmppanel_username=""
+      rtmppanel_password=""
+    fi
+
+    if [[ "$lang" == "de" ]]; then
+      echo -e "${INFO}Starte RTMPPanel Docker-Container...${NC}"
+    else
+      echo -e "${INFO}Starting RTMPPanel Docker container...${NC}"
+    fi
+
+    rtmp_api_url="http://${public_ip}:${rtmp_stats_port}"
+    rtmp_token=$(cat .rtmp_api_token 2>/dev/null || echo "")
+    if [[ -z "$rtmp_token" ]]; then
+      if [[ "$lang" == "de" ]]; then
+        echo -e "${YELLOW}Warnung: Kein RTMP API-Token gefunden (.rtmp_api_token). Stelle sicher, dass der RTMP-Server installiert wurde. RTMPPanel wird ohne gültigen Token gestartet.${NC}"
+      else
+        echo -e "${YELLOW}Warning: No RTMP API token found (.rtmp_api_token). Make sure the RTMP server was installed. RTMPPanel will start without a valid token.${NC}"
+      fi
+    fi
+    rtmppanel_secret=$(get_or_create_rtmppanel_secret)
+    TZ=$(grep -v '^$' /etc/timezone 2>/dev/null || timedatectl show --property=Timezone --value 2>/dev/null || echo UTC)
+
+    docker_pull_fallback "alexanderwagnerdev/rtmppanel:own" "ghcr.io/alexanderwagnerdev/rtmppanel:own"
+
+    if [[ "$rtmppanel_enable_login" =~ ^[JjYy] ]]; then
+      if [[ "$use_wud_labels" =~ ^[JjYy] ]]; then
+        docker run -d --name rtmppanel --restart unless-stopped \
+          --label "wud.watch=true" \
+          --label "wud.watch.digest=true" \
+          --label "wud.tag.include=^own$" \
+          -e REQUIRE_LOGIN=True \
+          -e USERNAME="${rtmppanel_username}" \
+          -e PASSWORD="${rtmppanel_password}" \
+          -e SECRET_KEY="${rtmppanel_secret}" \
+          -e LRTMP2_API_URL="${rtmp_api_url}" \
+          -e LRTMP2_API_TOKEN="${rtmp_token}" \
+          -e LRTMP2_DOMAIN="${public_ip}" \
+          -e LRTMP2_RTMP_PORT="${rtmp_port}" \
+          -e LANG="${lang}" \
+          -e TZ="${TZ}" \
+          -v rtmppanel-data:/data \
+          -p ${rtmppanel_port}:8000/tcp alexanderwagnerdev/rtmppanel:own
+      else
+        docker run -d --name rtmppanel --restart unless-stopped \
+          -e REQUIRE_LOGIN=True \
+          -e USERNAME="${rtmppanel_username}" \
+          -e PASSWORD="${rtmppanel_password}" \
+          -e SECRET_KEY="${rtmppanel_secret}" \
+          -e LRTMP2_API_URL="${rtmp_api_url}" \
+          -e LRTMP2_API_TOKEN="${rtmp_token}" \
+          -e LRTMP2_DOMAIN="${public_ip}" \
+          -e LRTMP2_RTMP_PORT="${rtmp_port}" \
+          -e LANG="${lang}" \
+          -e TZ="${TZ}" \
+          -v rtmppanel-data:/data \
+          -p ${rtmppanel_port}:8000/tcp alexanderwagnerdev/rtmppanel:own
+      fi
+    else
+      if [[ "$use_wud_labels" =~ ^[JjYy] ]]; then
+        docker run -d --name rtmppanel --restart unless-stopped \
+          --label "wud.watch=true" \
+          --label "wud.watch.digest=true" \
+          --label "wud.tag.include=^own$" \
+          -e REQUIRE_LOGIN=False \
+          -e SECRET_KEY="${rtmppanel_secret}" \
+          -e LRTMP2_API_URL="${rtmp_api_url}" \
+          -e LRTMP2_API_TOKEN="${rtmp_token}" \
+          -e LRTMP2_DOMAIN="${public_ip}" \
+          -e LRTMP2_RTMP_PORT="${rtmp_port}" \
+          -e LANG="${lang}" \
+          -e TZ="${TZ}" \
+          -v rtmppanel-data:/data \
+          -p ${rtmppanel_port}:8000/tcp alexanderwagnerdev/rtmppanel:own
+      else
+        docker run -d --name rtmppanel --restart unless-stopped \
+          -e REQUIRE_LOGIN=False \
+          -e SECRET_KEY="${rtmppanel_secret}" \
+          -e LRTMP2_API_URL="${rtmp_api_url}" \
+          -e LRTMP2_API_TOKEN="${rtmp_token}" \
+          -e LRTMP2_DOMAIN="${public_ip}" \
+          -e LRTMP2_RTMP_PORT="${rtmp_port}" \
+          -e LANG="${lang}" \
+          -e TZ="${TZ}" \
+          -v rtmppanel-data:/data \
+          -p ${rtmppanel_port}:8000/tcp alexanderwagnerdev/rtmppanel:own
+      fi
+    fi
+
+    health_check rtmppanel
+  else
+    echo -e "$rtmppanel_skip_msg"
+  fi
+
   print_available_services \
     "$app_url" \
     "$slspanel_port" \
@@ -862,7 +1100,8 @@ if [[ "$mainaction" == "1" ]]; then
     "$srt_player_port" \
     "$sls_stats_port" \
     "$rtmp_stats_port" \
-    "$rtmp_port"
+    "$rtmp_port" \
+    "$rtmppanel_port"
 
   echo -e "$done_msg"
   echo -e "$restart_msg"


### PR DESCRIPTION
## Summary
- `rtmp-server` now maps host port to `8080` (librtmp2 API/health) instead of `80` (old nginx-rtmp), and gets a persistent `rtmp-server-data:/data` Docker volume so the SQLite DB (streams + generated API token) survives container recreation
- New `extract_rtmp_api_token`/`extract_rtmp_api_token_with_retry`, matching librtmp2-server's multi-line first-boot token log (different format from SRTLA's single-line log)
- New RTMPPanel install block, structured like the existing SLSPanel block: install prompt, optional login (username/password), persistent `SECRET_KEY` (stored in `.rtmppanel_secret`, required to keep stored stream keys readable across restarts), persistent `rtmppanel-data:/data` volume
- `rtmppanel` added at `:own` tag, alongside the existing `rtmp-server`/`srtla-server`/`slspanel` `:own` tags
- `rtmppanel` added to stop/start/update/uninstall container + volume handling
- New `Port für RTMPPanel WebUI` prompt (default `8001`, to avoid clashing with SLSPanel's default `8000`)
- CI (`test-full-matrix.yml`): new `rtmppanel-only-no-login` variant, RTMPPanel exercised in all `all-*`/`all-no-wud-no-login` variants, container/volume assertions extended

## Why
Companion change to [AlexanderWagnerDev/rtmp-server-docker#18](https://github.com/AlexanderWagnerDev/rtmp-server-docker/pull/18), which switches `own`'s `rtmp-server` image from nginx-rtmp to librtmp2-server. This updates the installer to match that new image and wires up its `rtmppanel-docker` companion panel the same way SLSPanel is already wired up for SRTLA.

## Breaking change for existing own users
Anyone who already ran `own` with the old nginx-based `rtmp-server` container needs to fully **uninstall and reinstall** (not just "update") — the container port mapping changed from `80` to `8080` and there was previously no persistent volume.

## Test plan
- [x] `shellcheck` passes locally with the same flags as CI
- [ ] CI matrix green on this branch (lint / install-matrix / lifecycle / help-test)
- [ ] Manual install run with RTMPPanel + login enabled, verify panel can reach `rtmp-server`'s API with the extracted token


---
_Generated by [Claude Code](https://claude.ai/code/session_01Q6YVhWgLSUx9Js4qk68g5K)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/alexanderwagnerdev/stream-relay-installer/pull/10" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->